### PR TITLE
terraform module fix

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -114,3 +114,8 @@ resource "aws_iam_role_policy_attachment" "aws_limit_checker_policy_to_role" {
   policy_arn = aws_iam_policy.aws_limit_checker.arn
   role       = aws_iam_role.aws_limit_checker.name
 }
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = aws_iam_role.aws_limit_checker.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/lambda.tf
+++ b/lambda.tf
@@ -3,8 +3,8 @@ resource "aws_lambda_function" "scrape_limits" {
   handler          = "lambda.scrape_limits"
   role             = aws_iam_role.aws_limit_checker.arn
   runtime          = "python3.7"
-  filename         = "code/lambda.zip"
-  source_code_hash = filebase64sha256("code/lambda.zip")
+  filename         = "${path.module}/code/lambda.zip"
+  source_code_hash = filebase64sha256("${path.module}/code/lambda.zip")
   timeout          = 900
   environment {
     variables = {

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  region = "eu-west-1"
-}


### PR DESCRIPTION
I get the following error during the terraform plan:
```
Call to function "filebase64sha256" failed: no file exists at code/lambda.zip.
```

The fix is to use ${path.module} for lambda resource path.